### PR TITLE
Manual virutal env

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,5 @@ In this tutorial, you have learned how to implement Ultralytics YOLOv8 models in
 # Note
 Steps 1, 2, 5, 6, 7 and 8 only need to be done once to set up the federated learning environment in FEDn.
 
-To connect a new client, the only steps that needs to be followed are step 3, 4 and 9.
-Each client can have different configurations in the client_config.yaml file. This file needs to be downloaded from the repository separately for each client.
+To connect a new client, the only steps that needs to be followed are step 2, 3, 4 and 9.
+Each client can have different configurations in the client_config.yaml file to account for different hardware and training requirements.

--- a/client/fedn.yaml
+++ b/client/fedn.yaml
@@ -1,11 +1,9 @@
-python_env: python_env.yaml
-
 entry_points:
     build:
-        command: python model.py
+        command: python3 model.py
     startup:
-        command: python data.py
+        command: python3 data.py
     train:
-        command: python train.py
+        command: python3 train.py
     validate:
-        command: python validate.py
+        command: python3 validate.py

--- a/client/python_env.yaml
+++ b/client/python_env.yaml
@@ -1,9 +1,0 @@
-name: Ultralytics_FEDn
-build_dependencies:
-  - pip
-  - setuptools
-  - wheel
-dependencies:
-  - torch==2.4.1
-  - ultralytics==8.2.91
-  - fedn==0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fedn==0.16.0
 ultralytics==8.2.91
+torch==2.4.1


### PR DESCRIPTION
I've updated the compute package to use a manual virtual environment so we offer an example with this setting. 
This also speeds everything up since the user already has to install ultralytics and fedn.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R152): Updated the steps for connecting a new client to include step 2 and clarified the purpose of the `client_config.yaml` file.

Configuration updates:

* [`client/fedn.yaml`](diffhunk://#diff-dbd35847916d4abbd4621d0cd7d81b52573a99ae18f1c6702f78d933b2084b53L1-R9): Changed the commands to use `python3` instead of `python` to ensure compatibility with environments where Python 3 is the default.
* [`client/python_env.yaml`](diffhunk://#diff-44fec7fb448049b67a1609df80366d4be04e46a029bec73a2fb9b5a47609142eL1-L9): Removed the `python_env.yaml` file as it is no longer necessary for the current setup.