### PR TITLE
Updated instructions for fedn 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Before starting the training process, you need to connect the clients to the ser
 To connect a client to the server, you need to hand each client a client.yaml file. This file contains the necessary configurations for the client to connect to the server and gain access to the compute package. Connect clients by pressing the "Clients" button on the left hand side. Here you can download a client.yaml file for each client.
 Place the client.yaml file in the repository and start the client by running following command:
 ```bash
-fedn client start -in client.yaml --secure=True --force-ssl
+fedn client start -in client.yaml
 ```
 This starts the client and connects it to the server. Repeat this process for each client you want to connect to the server.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fedn==0.16.0
+fedn==0.19.0
 ultralytics==8.2.91
 torch==2.4.1


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change accounts for fedn version 0.19.0 by by removing the `--secure=True --force-ssl` options.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R132): Simplified the client start command by removing the `--secure=True --force-ssl` options.